### PR TITLE
fix(PricingInfo): accept non-String formattedPrice from JS

### DIFF
--- a/lib/src/models/seatsio_category.dart
+++ b/lib/src/models/seatsio_category.dart
@@ -45,9 +45,10 @@ class PricingInfo {
   PricingInfo({this.price, this.formattedPrice});
 
   factory PricingInfo.fromJson(Map<String, dynamic> json) {
+    final dynamic rawFormatted = json['formattedPrice'];
     return PricingInfo(
       price: (json['price'] as num?)?.toDouble(),
-      formattedPrice: json['formattedPrice'] as String?,
+      formattedPrice: rawFormatted == null ? null : rawFormatted.toString(),
     );
   }
 


### PR DESCRIPTION
Seats.io chart can send `pricing.formattedPrice` as int (e.g. 60) when the price is a whole number, but PricingInfo.fromJson casts to String? which throws TypeError — propagates up from SeatsioCategory.fromJson → SeatsioObject.fromJson → kills onObjectClicked/onObjectSelected callbacks silently on iOS WKWebView, breaking seat selection flow.

Fix: coerce via toString(). Works for int, double, String.